### PR TITLE
Update seed data

### DIFF
--- a/server/src/seeders/1597048908491-Project.ts
+++ b/server/src/seeders/1597048908491-Project.ts
@@ -14,18 +14,18 @@ export class Project1597048908491 implements MigrationInterface {
 		project1.name = 'Project name';
 		project1.key = 'PN';
 		project1.category = 'Business';
-		project1.lead = user1.id;
-		project1.creator = user1.id;
-		project1.defaultAssignee = user2.id;
+		project1.lead = user1;
+		project1.creator = user1;
+		project1.defaultAssignee = user2;
 		project1.id = '1fbda607-5934-484c-9667-bd35574a2f1e';
 
 		const project2 = new Projects();
 		project2.name = 'Our Project';
 		project2.key = 'ON';
 		project2.category = 'Software';
-		project2.lead = user2.id;
-		project2.creator = user2.id;
-		project2.defaultAssignee = user1.id;
+		project2.lead = user2;
+		project2.creator = user2;
+		project2.defaultAssignee = user1;
 		project2.id = 'e040e267-3533-4579-93fa-e749ca93f72f';
 		await getRepository('Projects').save([project1, project2]);
 

--- a/server/src/seeders/1597700889853-ProjectsPeople.ts
+++ b/server/src/seeders/1597700889853-ProjectsPeople.ts
@@ -1,6 +1,7 @@
 import { MigrationInterface, QueryRunner, getRepository, getCustomRepository } from 'typeorm';
 import { UserRepository } from '../repositories/user.repository';
 import { Projects } from '../entity/Projects';
+import { UserProfile } from '../entity/UserProfile';
 
 export class ProjectsPeople1597700889853 implements MigrationInterface {
 	public async up(queryRunner: QueryRunner): Promise<void> {
@@ -19,8 +20,8 @@ export class ProjectsPeople1597700889853 implements MigrationInterface {
 			},
 		});
 
-		const user1 = await userRepository.getByEmail('test@test.com');
-		const user2 = await userRepository.getByEmail('test1@test.com');
+		const user1 = await userRepository.getByEmail('test@test.com') as UserProfile;
+		const user2 = await userRepository.getByEmail('test1@test.com') as UserProfile;
 
 		user1.projects = [project2, project1];
 		user2.projects = [project1, project2];


### PR DESCRIPTION
This fixes errors on schema drop due to type inconsistency.

Errors like:
```
Error during schema drop:
src/seeders/1597048908491-Project.ts:17:3 - error TS2322: Type 'string' is not assignable to type 'UserProfile'.

17  	project1.lead = user1.id;
```