### PR TITLE
Remove isLoading update on SUCCESS_GET_RECENT_BOARDS

### DIFF
--- a/client/src/containers/Boards/logic/reducer.ts
+++ b/client/src/containers/Boards/logic/reducer.ts
@@ -14,7 +14,6 @@ export const boardReducer = createReducer<BoardsState>(initialState, {
 		return {
 			...state,
 			recentBoards: recentBoards.recentBoards,
-			isLoading: true,
 		};
 	},
 });


### PR DESCRIPTION
- Recent boards are used in Header container. And loading recent boards should not have effect on showing the loading spinner on Boards container.
- Bug was occurring in cases when SUCCESS_LOADING (changes isLoading to false) was triggered before SUCCESS_GET_RECENT_BOARDS (was changing isLoading to true) .